### PR TITLE
Proposal to fix oauth 2.0 incompatibility

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '<= 1.7.0'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
https://github.com/simi/omniauth-facebook/issues/363
We can lock `'omniauth-oauth2'` to `<=1.7.0` until `omniauth-facebook` support `omniauth 2.0`